### PR TITLE
Update squeaknode app to v0.1.191

### DIFF
--- a/apps/squeaknode/app.yml
+++ b/apps/squeaknode/app.yml
@@ -8,7 +8,7 @@ version: 1
 metadata:
   category: Social
   name: Squeaknode
-  version: 0.1.186
+  version: 0.1.191
   tagline: A peer-to-peer status feed with Lightning monetization
   description: >-
     The Squeaknode app allows you to create, view, buy, and sell squeaks. A
@@ -34,7 +34,7 @@ metadata:
   mainContainer: web
 containers:
   - name: web
-    image: ghcr.io/squeaknode/squeaknode:v0.1.186@sha256:3dcae780ae5c1707c30b4467a83bcf917768e011ba6693dd86289acb126e7df7
+    image: ghcr.io/squeaknode/squeaknode:v0.1.191@sha256:399efc33e4358c8017f342923ef729560906d1dec54c9a23121be1b5225d3964
     stop_grace_period: 1m
     port: 12994
     ports:


### PR DESCRIPTION
This version has several changes:
- Public key now used as identifier for user profiles instead of P2PKH Bitcoin address
- Schnorr signatures used to sign squeaks
- Private messages using ECDH shared secret
- Other UI improvements