### PR TITLE
Update Jam to `v0.0.4`

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -48,7 +48,7 @@ containers:
       jm_rpc_password: ${BITCOIN_RPC_PASS}
       jm_rpc_wallet_file: jm_webui_default
       jm_network: $BITCOIN_NETWORK
-      jm_max_cj_fee_abs: 30000
+      jm_max_cj_fee_abs: 300000
       jm_max_cj_fee_rel: 0.0003
     permissions:
       - bitcoind

--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -34,6 +34,7 @@ containers:
       - data/joinmarket:/root/.joinmarket
     environment:
       ENSURE_WALLET: 1
+      RESTORE_DEFAULT_CONFIG: 1
       APP_USER: citadel
       APP_PASSWORD: ${APP_SEED}
       jm_tor_control_host: $TOR_PROXY_IP

--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -3,7 +3,7 @@ version: "2"
 metadata:
   category: Wallets
   name: JAM
-  version: 0.0.3
+  version: 0.0.4
   tagline: JoinMarket's awesome, man
   description: JAM (JoinMarket's awesome, man) is a user-interface for JoinMarket
     with a focus on user-friendliness. It's time for top-notch privacy for your
@@ -25,7 +25,7 @@ metadata:
   defaultPassword: $APP_SEED
 containers:
   - name: joinmarket-webui
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.3-clientserver-v0.9.5
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.4-clientserver-v0.9.5
     restart: on-failure
     stop_grace_period: 1m
     init: true

--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -5,7 +5,7 @@ metadata:
   name: JAM
   version: 0.0.3
   tagline: JoinMarket's awesome, man
-  description: JAM (Joinmarket's awesome, man) is a user-interface for JoinMarket
+  description: JAM (JoinMarket's awesome, man) is a user-interface for JoinMarket
     with a focus on user-friendliness. It's time for top-notch privacy for your
     bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and
     privacy for all. The app provides sensible defaults and is easy to use for


### PR DESCRIPTION
All notable changes of the UI can be seen in the [Jam `v0.0.4` changelog](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.4). Most of the issues have been reported by early Citadel and Umbrel users. Thanks to all who helped to find and repair these bugs. :pray: 

Updates to the image:
- Adding [a slightly adapted default config](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/25):
  - use onion irc server instead of clearnet
  - add default max fee settings
- Support for websocket connection

In order to guarantee that all current users will benefit from the changes, an option to always use the adapted default config is introduced. It it also ensured that everyone already using Jam with an locally adapted version can opt-out of this behaviour. This mostly applies to power users (which Jam generally is not tailored at).

> With upstream changes https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1049 and https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1061 on the horizon, there is a chance to revert these changes and using a generated default configuration file once again.