### PR TITLE
Update Jam to `v0.0.5`

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -3,10 +3,10 @@ version: "2"
 metadata:
   category: Wallets
   name: JAM
-  version: 0.0.4
+  version: 0.0.5
   tagline: JoinMarket's awesome, man
-  description: JAM (JoinMarket's awesome, man) is a user-interface for JoinMarket
-    with a focus on user-friendliness. It's time for top-notch privacy for your
+  description: JAM (JoinMarket's awesome, man) is a web-interface for JoinMarket
+    with focus on user-friendliness. It's time for top-notch privacy for your
     bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and
     privacy for all. The app provides sensible defaults and is easy to use for
     beginners while still providing the features advanced users expect.
@@ -25,7 +25,7 @@ metadata:
   defaultPassword: $APP_SEED
 containers:
   - name: joinmarket-webui
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.4-clientserver-v0.9.5
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.5-clientserver-v0.9.5
     restart: on-failure
     stop_grace_period: 1m
     init: true


### PR DESCRIPTION
This version includes:
- joinmarket-webui: [v0.0.5](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.5)
- joinmarket-clientserver: [v0.9.5](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.5)

All notable changes of the UI can be seen in the [Jam `v0.0.5` changelog](https://github.com/joinmarket-webui/joinmarket-webui/blob/v0.0.5/CHANGELOG.md)

Updates to the image:
- Colorize bash output [#28](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/28)