### PR TITLE
Update Jam to v0.0.6

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -8,7 +8,7 @@ version: 3
 metadata:
   category: Wallets
   name: JAM
-  version: 0.0.5
+  version: 0.0.6
   tagline: JoinMarket's awesome, man
   description: JAM (JoinMarket's awesome, man) is a web-interface for JoinMarket
     with focus on user-friendliness. It's time for top-notch privacy for your
@@ -30,7 +30,7 @@ metadata:
   defaultPassword: $APP_SEED
 containers:
   - name: joinmarket-webui
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.5-clientserver-v0.9.5
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.6-clientserver-v0.9.6
     restart: on-failure
     stop_grace_period: 1m
     init: true


### PR DESCRIPTION
This version includes:
- joinmarket-webui: [v0.0.6](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.6)
- joinmarket-clientserver: [v0.9.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.6)

All notable changes of the UI can be seen in the [Jam v0.0.6 changelog](https://github.com/joinmarket-webui/joinmarket-webui/blob/v0.0.6/CHANGELOG.md)

Updates to the image:
- increase api request timeout from 60sec to 5min [#34](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/34)
- update to default config for v0.9.6 [#32](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/32)