### PR TITLE
Update app Jam from `v0.0.6` to `v0.0.9`

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -8,7 +8,7 @@ version: 3
 metadata:
   category: Wallets
   name: JAM
-  version: 0.0.6
+  version: 0.0.9
   tagline: JoinMarket's awesome, man
   description: JAM (JoinMarket's awesome, man) is a web-interface for JoinMarket
     with focus on user-friendliness. It's time for top-notch privacy for your
@@ -30,7 +30,7 @@ metadata:
   defaultPassword: $APP_SEED
 containers:
   - name: joinmarket-webui
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.6-clientserver-v0.9.6
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.9-clientserver-v0.9.6
     restart: on-failure
     stop_grace_period: 1m
     init: true
@@ -38,8 +38,9 @@ containers:
     data:
       - data/joinmarket:/root/.joinmarket
     environment:
-      ENSURE_WALLET: 1
-      RESTORE_DEFAULT_CONFIG: 1
+      RESTORE_DEFAULT_CONFIG: "true"
+      REMOVE_LOCK_FILES: "true"
+      ENSURE_WALLET: "true"
       APP_USER: citadel
       APP_PASSWORD: ${APP_SEED}
       jm_tor_control_host: $TOR_PROXY_IP


### PR DESCRIPTION
This version includes:
- joinmarket-webui: [v0.0.9](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.9)
- joinmarket-clientserver: [v0.9.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.6)

All notable changes of the UI can be seen in the [Jam v0.0.9 changelog](https://github.com/joinmarket-webui/joinmarket-webui/blob/v0.0.9/CHANGELOG.md)

Updates to the image:
- remove leftover wallet lockfiles before startup