### PR TITLE
Fix Synapse args format

### DIFF
--- a/apps/synapse/app.yml
+++ b/apps/synapse/app.yml
@@ -31,9 +31,9 @@ containers:
       GID: "1000"
       SYNAPSE_HTTP_PORT: 8008
       SYNAPSE_SERVER_NAME: ${APP_HIDDEN_SERVICE}
-      SYNAPSE_REPORT_STATS: yes
-      SYNAPSE_ENABLE_REGISTRATION: yes
-      SYNAPSE_NO_TLS: yes
+      SYNAPSE_REPORT_STATS: "yes"
+      SYNAPSE_ENABLE_REGISTRATION: "yes"
+      SYNAPSE_NO_TLS: "yes"
     name: server
     data:
       - data/synapse:/data


### PR DESCRIPTION
Closes https://github.com/runcitadel/citadel/issues/10

This will only be a temporary fix until the update task will change the file again. The actual problem is with the app.yml converter. See https://github.com/runcitadel/citadel/issues/10#issuecomment-1193192117