### PR TITLE
Update Jam from v0.0.9 to v0.0.10

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -43,17 +43,11 @@ containers:
       ENSURE_WALLET: "true"
       APP_USER: citadel
       APP_PASSWORD: ${APP_SEED}
-      jm_tor_control_host: $TOR_PROXY_IP
-      jm_tor_control_port: 29051
-      jm_onion_socks5_host: $TOR_PROXY_IP
-      jm_onion_socks5_port: $TOR_PROXY_PORT
-      jm_socks5_host: $TOR_PROXY_IP
-      jm_socks5_port: $TOR_PROXY_PORT
+      jm_network: $BITCOIN_NETWORK
       jm_rpc_host: $BITCOIN_IP
       jm_rpc_port: $BITCOIN_RPC_PORT
       jm_rpc_user: $BITCOIN_RPC_USER
       jm_rpc_password: ${BITCOIN_RPC_PASS}
       jm_rpc_wallet_file: jm_webui_default
-      jm_network: $BITCOIN_NETWORK
       jm_max_cj_fee_abs: 300000
       jm_max_cj_fee_rel: 0.0003

--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -16,10 +16,10 @@ metadata:
     privacy for all. The app provides sensible defaults and is easy to use for
     beginners while still providing the features advanced users expect.
   developers:
-    JAM developers: https://github.com/joinmarket-webui/joinmarket-webui
+    JAM developers: https://github.com/joinmarket-webui/jam
   dependencies:
     - bitcoind
-  repo: https://github.com/joinmarket-webui/joinmarket-webui
+  repo: https://github.com/joinmarket-webui/jam
   support: https://t.me/JoinMarketWebUI
   gallery:
     - 1.jpg

--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -8,7 +8,7 @@ version: 3
 metadata:
   category: Wallets
   name: JAM
-  version: 0.0.9
+  version: 0.0.10
   tagline: JoinMarket's awesome, man
   description: JAM (JoinMarket's awesome, man) is a web-interface for JoinMarket
     with focus on user-friendliness. It's time for top-notch privacy for your
@@ -30,7 +30,7 @@ metadata:
   defaultPassword: $APP_SEED
 containers:
   - name: joinmarket-webui
-    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.9-clientserver-v0.9.6
+    image: ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.10-clientserver-v0.9.6
     restart: on-failure
     stop_grace_period: 1m
     init: true


### PR DESCRIPTION
This version includes:
- Jam: [v0.0.10](https://github.com/joinmarket-webui/jam/releases/tag/v0.0.10)
- joinmarket-clientserver: [v0.9.6](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.6)

All notable changes of the UI can be seen in the [Jam v0.0.10 changelog](https://github.com/joinmarket-webui/jam/blob/v0.0.10/CHANGELOG.md)

Updates to the image:
- opt-in for basic authentication
- run local tor daemon