### PR TITLE
Update Jam to v0.1.1

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -1,9 +1,9 @@
 citadel_version: 4
 metadata:
   name: JAM
-  version: 0.1.0
+  version: 0.1.1
   category: Wallets
-  tagline: JoinMarket's awesome, man
+  tagline: Your sats. Your privacy. Your profit.
   developers:
     JAM developers: https://github.com/joinmarket-webui/jam
   permissions:
@@ -19,10 +19,10 @@ metadata:
   - 5.jpg
   defaultPassword: $APP_SEED
   torOnly: false
-  description: JAM (JoinMarket's awesome, man) is a web-interface for JoinMarket with focus on user-friendliness. It's time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all. The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
+  description: Jam is a user-interface for JoinMarket with focus on user-friendliness. It's time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all. The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 services:
   main:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.0-clientserver-v0.9.8
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8
     stop_grace_period: 1m
     restart: on-failure
     init: true
@@ -30,15 +30,13 @@ services:
       jm_rpc_port: $BITCOIN_RPC_PORT
       jm_rpc_password: ${BITCOIN_RPC_PASS}
       jm_rpc_user: $BITCOIN_RPC_USER
-      APP_USER: citadel
       jm_rpc_host: $BITCOIN_IP
       jm_network: $BITCOIN_NETWORK
-      jm_max_cj_fee_abs: '300000'
-      jm_max_cj_fee_rel: '0.0003'
       jm_rpc_wallet_file: jm_webui_default
       RESTORE_DEFAULT_CONFIG: 'true'
       REMOVE_LOCK_FILES: 'true'
       ENSURE_WALLET: 'true'
+      APP_USER: citadel
       APP_PASSWORD: ${APP_SEED}
     port: 80
     mounts:


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.1](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.1)
- joinmarket-clientserver: [v0.9.8](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)

All notable changes of the UI can be seen in the [Jam v0.1.1 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.1/CHANGELOG.md)

Updates to the image:
- feat: randomize mandatory fee config values [#66](https://github.com/joinmarket-webui/jam-docker/pull/66) 