### PR TITLE
Update Jam v0.1.2

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -1,11 +1,11 @@
 citadel_version: 4
 metadata:
-  name: JAM
-  version: 0.1.1
+  name: Jam
+  version: 0.1.2
   category: Wallets
   tagline: Your sats. Your privacy. Your profit.
   developers:
-    JAM developers: https://github.com/joinmarket-webui/jam
+    Jam developers: https://github.com/joinmarket-webui/jam
   permissions:
   - bitcoind
   repo:
@@ -22,7 +22,7 @@ metadata:
   description: Jam is a user-interface for JoinMarket with focus on user-friendliness. It's time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all. The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 services:
   main:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.2-clientserver-v0.9.8
     stop_grace_period: 1m
     restart: on-failure
     init: true

--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -22,7 +22,7 @@ metadata:
   description: Jam is a user-interface for JoinMarket with focus on user-friendliness. It's time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all. The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 services:
   main:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.2-clientserver-v0.9.8
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.2-clientserver-v0.9.8@sha256:c23fdf063d6221bc923fb1ad025c4e51b0b2f18968d3664e1f3964f43f51cd09
     stop_grace_period: 1m
     restart: on-failure
     init: true


### PR DESCRIPTION
This version includes:
- Jam: [v0.1.2](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.2)
- joinmarket-clientserver: [v0.9.8](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)

All notable changes of the UI can be seen in the [Jam v0.1.2 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.2/CHANGELOG.md)

Updates to the image:
- fix: ensure jm working dir exists [#68](https://github.com/joinmarket-webui/jam-docker/pull/68)
- feat(init): use dinit instead of supervisor [#69 ](https://github.com/joinmarket-webui/jam-docker/pull/69)