### PR TITLE
Update Jam to v0.1.5

### DIFF
--- a/apps/jam/app.yml
+++ b/apps/jam/app.yml
@@ -1,7 +1,7 @@
 citadel_version: 4
 metadata:
   name: JAM
-  version: 0.1.1
+  version: 0.1.5
   category: Wallets
   tagline: Your sats. Your privacy. Your profit.
   developers:
@@ -22,7 +22,7 @@ metadata:
   description: Jam is a user-interface for JoinMarket with focus on user-friendliness. It's time for top-notch privacy for your bitcoin. Widespread use of JoinMarket improves bitcoin's fungibility and privacy for all. The app provides sensible defaults and is easy to use for beginners while still providing the features advanced users expect.
 services:
   main:
-    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8
+    image: ghcr.io/joinmarket-webui/jam-standalone:v0.1.5-clientserver-v0.9.9@sha256:c8bf944000eb8b3b5666ac037440a4904f9c3baa8665c52081a9e5092d6bd275
     stop_grace_period: 1m
     restart: on-failure
     init: true


### PR DESCRIPTION
- Jam: [v0.1.5](https://github.com/joinmarket-webui/jam/releases/tag/v0.1.5)
- joinmarket-clientserver: [v0.9.9](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.9)

All notable changes of the UI can be seen in the [Jam v0.1.5 changelog](https://github.com/joinmarket-webui/jam/blob/v0.1.5/CHANGELOG.md)